### PR TITLE
Fix url for python apps  message template document

### DIFF
--- a/send-messages-flight-app-python/flights.py
+++ b/send-messages-flight-app-python/flights.py
@@ -8,7 +8,7 @@ LICENSE file in the root directory of this source tree.
 def get_flights():
   return [{
     "flight_id": 1,
-    "document": 'https://github.com/fbsamples/whatsapp-api-examples/blob/main/whatsapp-api-example-app-python/FlightConfirmation.pdf',
+    "document": 'https://github.com/fbsamples/whatsapp-api-examples/blob/main/send-messages-flight-app-python/FlightConfirmation.pdf',
     "thumbnail": 'https://upload.wikimedia.org/wikipedia/commons/thumb/f/f8/Aerial_view_of_Bajra_Sandhi_Monument_Denpasar_Bali_Indonesia.jpg/250px-Aerial_view_of_Bajra_Sandhi_Monument_Denpasar_Bali_Indonesia.jpg',
     "origin": 'Singapore (SIN)',
     "destination": 'Denpasar (DPS)',
@@ -16,16 +16,15 @@ def get_flights():
   },
   {
     "flight_id": 2,
-    "document": 'https://github.com/fbsamples/whatsapp-api-examples/blob/main/whatsapp-api-example-app-python/FlightConfirmation.pdf',
+    "document": 'https://github.com/fbsamples/whatsapp-api-examples/blob/main/send-messages-flight-app-python/FlightConfirmation.pdf',
     "thumbnail": 'https://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Parliament_at_Sunset.JPG/275px-Parliament_at_Sunset.JPG',
     "origin": 'New York (JFK)',
     "destination": 'London (LHR)',
     "time": 'June 25, 2022 - 9:15 PM'
   },
-  
   {
     "flight_id": 3,
-    "document": 'https://github.com/fbsamples/whatsapp-api-examples/blob/main/whatsapp-api-example-app-python/FlightConfirmation.pdf',
+    "document": 'https://github.com/fbsamples/whatsapp-api-examples/blob/main/send-messages-flight-app-python/FlightConfirmation.pdf',
     "thumbnail": 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a0/Sydney_Australia._%2821339175489%29.jpg/250px-Sydney_Australia._%2821339175489%29.jpg',
     "origin": 'Beijing (PEK)',
     "destination": 'Sydney (SYD)',
@@ -33,7 +32,7 @@ def get_flights():
   },
   {
     "flight_id": 4,
-    "document": 'https://github.com/fbsamples/whatsapp-api-examples/blob/main/whatsapp-api-example-app-python/FlightConfirmation.pdf',
+    "document": 'https://github.com/fbsamples/whatsapp-api-examples/blob/main/send-messages-flight-app-python/FlightConfirmation.pdf',
     "thumbnail": 'https://upload.wikimedia.org/wikipedia/commons/thumb/a/a5/Mouth_of_Miami_River_20100211.jpg/220px-Mouth_of_Miami_River_20100211.jpg',
     "origin": 'São Paulo (GRU)',
     "destination": 'Miami (MIA)',


### PR DESCRIPTION
Current URL doesn't load:

https://github.com/fbsamples/whatsapp-api-examples/blob/main/whatsapp-api-example-app-python/FlightConfirmation.pdf

Changing to correct URL:

https://github.com/fbsamples/whatsapp-api-examples/blob/main/send-messages-flight-app-python/FlightConfirmation.pdf